### PR TITLE
List tours with name and description

### DIFF
--- a/virotour/lib/src/app.dart
+++ b/virotour/lib/src/app.dart
@@ -47,7 +47,7 @@ class App extends StatelessWidget {
                     return const TourDetailsView();
                   case TourListView.routeName:
                   default:
-                    return const TourListView();
+                    return const TourListView(items: [],);
                 }
               },
             );

--- a/virotour/lib/src/app.dart
+++ b/virotour/lib/src/app.dart
@@ -47,7 +47,9 @@ class App extends StatelessWidget {
                     return const TourDetailsView();
                   case TourListView.routeName:
                   default:
-                    return const TourListView(items: [],);
+                    return const TourListView(
+                      items: [],
+                    );
                 }
               },
             );

--- a/virotour/lib/src/tour/tour.dart
+++ b/virotour/lib/src/tour/tour.dart
@@ -4,6 +4,5 @@ class Tour {
   final String description;
   final String id;
 
-
   Tour({required this.tourName, required this.description, required this.id});
 }

--- a/virotour/lib/src/tour/tour.dart
+++ b/virotour/lib/src/tour/tour.dart
@@ -1,6 +1,9 @@
 // A placeholder class that represents an entity or model.
 class Tour {
-  const Tour(this.id);
+  final String tourName;
+  final String description;
+  final String id;
 
-  final int id;
+
+  Tour({required this.tourName, required this.description, required this.id});
 }

--- a/virotour/lib/src/tour/tour_edit_view.dart
+++ b/virotour/lib/src/tour/tour_edit_view.dart
@@ -1,5 +1,7 @@
 // tour_edit_view.dart
 
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:virotour/src/tour/tour.dart';
@@ -94,8 +96,11 @@ class _TourEditViewState extends State<TourEditView> {
                         'name': _nameController.text,
                         'description': _descriptionController.text,
                       };
-                      final response =
-                          await http.post(Uri.parse(url), body: body);
+                      final response = await http.post(
+                        Uri.parse(url),
+                        headers: {'Content-Type': 'application/json'},
+                        body: json.encode(body),
+                      );
                       if (response.statusCode == 200) {
                         Navigator.pop(context);
                       } else {

--- a/virotour/lib/src/tour/tour_edit_view.dart
+++ b/virotour/lib/src/tour/tour_edit_view.dart
@@ -1,0 +1,187 @@
+// tour_edit_view.dart
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:virotour/src/tour/tour.dart';
+
+class TourEditView extends StatefulWidget {
+  static const routeName = '/tour_edit';
+
+  final Tour tour;
+
+  const TourEditView({required this.tour, super.key});
+
+  @override
+  _TourEditViewState createState() => _TourEditViewState();
+}
+
+class _TourEditViewState extends State<TourEditView> {
+  late TextEditingController _nameController;
+  late TextEditingController _descriptionController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.tour.tourName);
+    _descriptionController =
+        TextEditingController(text: widget.tour.description);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Tour'),
+      ),
+      body: Center(
+        child: Container(
+          constraints: const BoxConstraints(
+            maxWidth: 600,
+          ),
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 16.0),
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Name',
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              TextFormField(
+                controller: _descriptionController,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Description',
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                    style: OutlinedButton.styleFrom(
+                      backgroundColor: Colors.blue,
+                    ),
+                    child: const Text(
+                      'Cancel',
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16.0),
+                  ElevatedButton(
+                    onPressed: () async {
+                      final url =
+                          'http://192.168.1.217:5000/api/update/tour/${widget.tour.id}';
+                      final body = {
+                        'id': widget.tour.id,
+                        'name': _nameController.text,
+                        'description': _descriptionController.text,
+                      };
+                      final response =
+                          await http.post(Uri.parse(url), body: body);
+                      if (response.statusCode == 200) {
+                        Navigator.pop(context);
+                      } else {
+                        showDialog(
+                          context: context,
+                          builder: (context) => AlertDialog(
+                            title: const Text('Failed to update tour'),
+                            content:
+                                Text('Status code: ${response.statusCode}'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(context),
+                                child: const Text('OK'),
+                              ),
+                            ],
+                          ),
+                        );
+                      }
+                    },
+                    style: OutlinedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                    ),
+                    child: const Text('Save'),
+                  ),
+                  const SizedBox(width: 16.0),
+                  OutlinedButton(
+                    onPressed: () async {
+                      final confirmDelete = await showDialog<bool>(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: const Text('Confirm Deletion'),
+                          content: const Text(
+                            'Are you sure you want to delete this tour?',
+                          ),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, false),
+                              child: const Text('Cancel'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, true),
+                              child: const Text('Delete'),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirmDelete == true) {
+                        final url =
+                            'http://192.168.1.217:5000/api/delete/tour/${widget.tour.id}';
+                        final response = await http.delete(Uri.parse(url));
+                        if (response.statusCode == 200) {
+                          Navigator.pop(context);
+                        } else {
+                          showDialog(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text('Failed to delete tour'),
+                              content:
+                                  Text('Status code: ${response.statusCode}'),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(context),
+                                  child: const Text('OK'),
+                                ),
+                              ],
+                            ),
+                          );
+                        }
+                      }
+                    },
+                    style: OutlinedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                    ),
+                    child: const Text(
+                      'Delete',
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/virotour/lib/src/tour/tour_list_view.dart
+++ b/virotour/lib/src/tour/tour_list_view.dart
@@ -6,26 +6,32 @@ import 'package:virotour/src/settings/settings_view.dart';
 import 'package:virotour/src/tour/tour.dart';
 import 'package:virotour/src/tour/tour_details_view.dart';
 
-class TourListView extends StatelessWidget {
+class TourListView extends StatefulWidget {
+  const TourListView({
+    Key? key,
+    required this.items,
+  }) : super(key: key);
+
+  static const routeName = '/';
+
+  final List<Tour> items;
+
+  @override
+  _TourListViewState createState() => _TourListViewState();
+}
+
+class _TourListViewState extends State<TourListView> {
+  late Future<List<Tour>> _tourData;
+
+  @override
+  void initState() {
+    super.initState();
+    _tourData = fetchData();
+  }
+
   static Future<List<Tour>> fetchData() async {
     // TODO: Implement fetching the tour data from an API endpoint
-    /*
-    final response = await http.get(Uri.parse('https://example.com/tours'));
-    if (response.statusCode == 200) {
-      final responseData = jsonDecode(response.body);
-      final data = responseData['data'];
-    } else {
-      throw Exception("failed to load tour data!");
-    }
-
-    return data
-        .map((tour) => Tour(
-        id: tour['id'].toString(),
-        tourName: tour['tour_name'].toString(),
-        description: tour['description'].toString()))
-        .toList();
-
-     */
+    // final response = await http.get(Uri.parse('https://virotour.com/tours/endpoint'));
     final response = [
       {
         'data': {
@@ -45,26 +51,21 @@ class TourListView extends StatelessWidget {
       }
     ];
 
+    // if (response.statusCode == 200) {
+    //   final responseData = jsonDecode(response.body);
     final data = response[0]['data']!['tours'] as List<dynamic>;
 
     return data
         .map((tour) => Tour(
-            id: tour['id'].toString(),
-            tourName: tour['tour_name'].toString(),
-            description: tour['description'].toString()))
+              id: tour['id'].toString(),
+              tourName: tour['tour_name'].toString(),
+              description: tour['description'].toString(),
+            ))
         .toList();
+    // } else {
+    //   throw Exception("Failed to load tour data!");
+    // }
   }
-
-  static final Future<List<Tour>> tourData = fetchData();
-
-  const TourListView({
-    Key? key,
-    required this.items,
-  }) : super(key: key);
-
-  static const routeName = '/';
-
-  final List<Tour> items;
 
   @override
   Widget build(BuildContext context) {
@@ -73,64 +74,61 @@ class TourListView extends StatelessWidget {
         title: const Text('Tours'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              setState(() {
+                _tourData = fetchData();
+              });
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
-              // Navigate to the settings page. If the user leaves and returns
-              // to the app after it has been killed while running in the
-              // background, the navigation stack is restored.
               Navigator.restorablePushNamed(context, SettingsView.routeName);
             },
           ),
         ],
       ),
-
-      // To work with lists that may contain a large number of items, it’s best
-      // to use the ListView.builder constructor.
-      //
-      // In contrast to the default ListView constructor, which requires
-      // building all Widgets up front, the ListView.builder constructor lazily
-      // builds Widgets as they’re scrolled into view.
-      body: FutureBuilder<List<Tour>>(
-        future: tourData,
-        builder: (context, snapshot) {
-          if (snapshot.hasData) {
-            final items = snapshot.data!;
-            return ListView.builder(
-              // Providing a restorationId allows the ListView to restore the
-              // scroll position when a user leaves and returns to the app after it
-              // has been killed while running in the background.
-              restorationId: 'tourListView',
-              itemCount: items.length,
-              itemBuilder: (BuildContext context, int index) {
-                final item = items[index];
-
-                return ListTile(
-                  // Show the tour name and description
-                  title: Text(item.tourName),
-                  subtitle: Text(item.description),
-                  leading: const CircleAvatar(
-                    foregroundImage:
-                        AssetImage('assets/images/virotour_logo.png'),
-                  ),
-                  onTap: () {
-                    // Navigate to the details page. If the user leaves and returns to
-                    // the app after it has been killed while running in the
-                    // background, the navigation stack is restored.
-                    // This needs to be updated to use the specific tour's data when the api is available.
-                    Navigator.restorablePushNamed(
-                      context,
-                      TourDetailsView.routeName,
-                    );
-                  },
-                );
-              },
-            );
-          } else if (snapshot.hasError) {
-            return Text('Error: ${snapshot.error}');
-          } else {
-            return const Center(child: CircularProgressIndicator());
-          }
+      body: RefreshIndicator(
+        onRefresh: () async {
+          setState(() {
+            _tourData = fetchData();
+          });
         },
+        child: FutureBuilder<List<Tour>>(
+          future: _tourData,
+          builder: (context, snapshot) {
+            if (snapshot.hasData) {
+              final items = snapshot.data!;
+              return ListView.builder(
+                restorationId: 'tourListView',
+                itemCount: items.length,
+                itemBuilder: (BuildContext context, int index) {
+                  final item = items[index];
+
+                  return ListTile(
+                    title: Text(item.tourName),
+                    subtitle: Text(item.description),
+                    leading: const CircleAvatar(
+                      foregroundImage:
+                          AssetImage('assets/images/virotour_logo.png'),
+                    ),
+                    onTap: () {
+                      Navigator.restorablePushNamed(
+                        context,
+                        TourDetailsView.routeName,
+                      );
+                    },
+                  );
+                },
+              );
+            } else if (snapshot.hasError) {
+              return Text('Error: ${snapshot.error}');
+            } else {
+              return const Center(child: CircularProgressIndicator());
+            }
+          },
+        ),
       ),
     );
   }

--- a/virotour/lib/src/tour/tour_list_view.dart
+++ b/virotour/lib/src/tour/tour_list_view.dart
@@ -95,8 +95,14 @@ class TourListView extends StatelessWidget {
                     AssetImage('assets/images/virotour_logo.png'),
                   ),
                   onTap: () {
-                    // TODO: Call the API to get the tour details and navigate
-                    // to the details page.
+                    // Navigate to the details page. If the user leaves and returns to
+                    // the app after it has been killed while running in the
+                    // background, the navigation stack is restored.
+                    // This needs to be updated to use the specific tour's data when the api is available.
+                    Navigator.restorablePushNamed(
+                    context,
+                    TourDetailsView.routeName,
+                    );
                   },
                 );
               },

--- a/virotour/lib/src/tour/tour_list_view.dart
+++ b/virotour/lib/src/tour/tour_list_view.dart
@@ -1,14 +1,48 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:virotour/src/settings/settings_view.dart';
 import 'package:virotour/src/tour/tour.dart';
 import 'package:virotour/src/tour/tour_details_view.dart';
 
 class TourListView extends StatelessWidget {
+  static Future<List<Tour>> fetchData() async {
+    // TODO: Implement fetching the tour data from an API endpoint
+    /*
+    final response = await http.get(Uri.parse('https://example.com/tours'));
+    if (response.statusCode == 200) {
+      final responseData = jsonDecode(response.body);
+      final data = responseData['data'];
+    } else {
+      throw Exception("failed to load tour data!");
+    }
+
+    return data
+        .map((tour) => Tour(
+        id: tour['id'].toString(),
+        tourName: tour['tour_name'].toString(),
+        description: tour['description'].toString()))
+        .toList();
+
+     */
+    final response = [{'data': {"tours":[{"tour_name": "example tour 1", "description": "This is an example tour", "id": 1}, {"tour_name": "example tour 2", "description": "This is another example tour", "id": 2}]}}];
+
+    final data = response[0]['data']!['tours'] as List<dynamic>;
+
+    return data.map((tour) => Tour(
+        id: tour['id'].toString(),
+        tourName: tour['tour_name'].toString(),
+        description: tour['description'].toString()))
+        .toList();
+  }
+
+  static final Future<List<Tour>> tourData = fetchData();
+
   const TourListView({
-    super.key,
-    // TODO: Get the list of tours from GET /
-    this.items = const [Tour(1), Tour(2), Tour(3)],
-  });
+    Key? key,
+    required this.items,
+  }) : super(key: key);
 
   static const routeName = '/';
 
@@ -38,32 +72,40 @@ class TourListView extends StatelessWidget {
       // In contrast to the default ListView constructor, which requires
       // building all Widgets up front, the ListView.builder constructor lazily
       // builds Widgets as they’re scrolled into view.
-      body: ListView.builder(
-        // Providing a restorationId allows the ListView to restore the
-        // scroll position when a user leaves and returns to the app after it
-        // has been killed while running in the background.
-        restorationId: 'tourListView',
-        itemCount: items.length,
-        itemBuilder: (BuildContext context, int index) {
-          final item = items[index];
+      body: FutureBuilder<List<Tour>>(
+        future: tourData,
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            final items = snapshot.data!;
+            return ListView.builder(
+              // Providing a restorationId allows the ListView to restore the
+              // scroll position when a user leaves and returns to the app after it
+              // has been killed while running in the background.
+              restorationId: 'tourListView',
+              itemCount: items.length,
+              itemBuilder: (BuildContext context, int index) {
+                final item = items[index];
 
-          return ListTile(
-            // TODO: Show tour name
-            title: Text('Tour ${item.id}'),
-            leading: const CircleAvatar(
-              foregroundImage: AssetImage('assets/images/virotour_logo.png'),
-            ),
-            // TODO: ontap = call GET /tour/<tour_id>
-            onTap: () {
-              // Navigate to the details page. If the user leaves and returns to
-              // the app after it has been killed while running in the
-              // background, the navigation stack is restored.
-              Navigator.restorablePushNamed(
-                context,
-                TourDetailsView.routeName,
-              );
-            },
-          );
+                return ListTile(
+                  // Show the tour name and description
+                  title: Text(item.tourName),
+                  subtitle: Text(item.description),
+                  leading: const CircleAvatar(
+                    foregroundImage:
+                    AssetImage('assets/images/virotour_logo.png'),
+                  ),
+                  onTap: () {
+                    // TODO: Call the API to get the tour details and navigate
+                    // to the details page.
+                  },
+                );
+              },
+            );
+          } else if (snapshot.hasError) {
+            return Text('Error: ${snapshot.error}');
+          } else {
+            return const Center(child: CircularProgressIndicator());
+          }
         },
       ),
     );

--- a/virotour/lib/src/tour/tour_list_view.dart
+++ b/virotour/lib/src/tour/tour_list_view.dart
@@ -26,14 +26,32 @@ class TourListView extends StatelessWidget {
         .toList();
 
      */
-    final response = [{'data': {"tours":[{"tour_name": "example tour 1", "description": "This is an example tour", "id": 1}, {"tour_name": "example tour 2", "description": "This is another example tour", "id": 2}]}}];
+    final response = [
+      {
+        'data': {
+          "tours": [
+            {
+              "tour_name": "example tour 1",
+              "description": "This is an example tour",
+              "id": 1
+            },
+            {
+              "tour_name": "example tour 2",
+              "description": "This is another example tour",
+              "id": 2
+            }
+          ]
+        }
+      }
+    ];
 
     final data = response[0]['data']!['tours'] as List<dynamic>;
 
-    return data.map((tour) => Tour(
-        id: tour['id'].toString(),
-        tourName: tour['tour_name'].toString(),
-        description: tour['description'].toString()))
+    return data
+        .map((tour) => Tour(
+            id: tour['id'].toString(),
+            tourName: tour['tour_name'].toString(),
+            description: tour['description'].toString()))
         .toList();
   }
 
@@ -92,7 +110,7 @@ class TourListView extends StatelessWidget {
                   subtitle: Text(item.description),
                   leading: const CircleAvatar(
                     foregroundImage:
-                    AssetImage('assets/images/virotour_logo.png'),
+                        AssetImage('assets/images/virotour_logo.png'),
                   ),
                   onTap: () {
                     // Navigate to the details page. If the user leaves and returns to
@@ -100,8 +118,8 @@ class TourListView extends StatelessWidget {
                     // background, the navigation stack is restored.
                     // This needs to be updated to use the specific tour's data when the api is available.
                     Navigator.restorablePushNamed(
-                    context,
-                    TourDetailsView.routeName,
+                      context,
+                      TourDetailsView.routeName,
                     );
                   },
                 );

--- a/virotour/lib/src/tour/tour_list_view.dart
+++ b/virotour/lib/src/tour/tour_list_view.dart
@@ -8,9 +8,9 @@ import 'package:virotour/src/tour/tour_details_view.dart';
 
 class TourListView extends StatefulWidget {
   const TourListView({
-    Key? key,
+    super.key,
     required this.items,
-  }) : super(key: key);
+  });
 
   static const routeName = '/';
 
@@ -30,41 +30,24 @@ class _TourListViewState extends State<TourListView> {
   }
 
   static Future<List<Tour>> fetchData() async {
-    // TODO: Implement fetching the tour data from an API endpoint
-    // final response = await http.get(Uri.parse('https://virotour.com/tours/endpoint'));
-    final response = [
-      {
-        'data': {
-          "tours": [
-            {
-              "tour_name": "example tour 1",
-              "description": "This is an example tour",
-              "id": 1
-            },
-            {
-              "tour_name": "example tour 2",
-              "description": "This is another example tour",
-              "id": 2
-            }
-          ]
-        }
-      }
-    ];
+    final response =
+        await http.get(Uri.parse('http://192.168.1.217:5000/api/tours'));
 
-    // if (response.statusCode == 200) {
-    //   final responseData = jsonDecode(response.body);
-    final data = response[0]['data']!['tours'] as List<dynamic>;
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
 
-    return data
-        .map((tour) => Tour(
-              id: tour['id'].toString(),
-              tourName: tour['tour_name'].toString(),
-              description: tour['description'].toString(),
-            ))
-        .toList();
-    // } else {
-    //   throw Exception("Failed to load tour data!");
-    // }
+      final tours = data['tours'] as List<dynamic>;
+
+      return tours
+          .map((tour) => Tour(
+                id: tour['id'].toString(),
+                tourName: tour['name'].toString(),
+                description: tour['description'].toString(),
+              ))
+          .toList();
+    } else {
+      throw Exception("Failed to load tour data!");
+    }
   }
 
   @override

--- a/virotour/lib/src/tour/tour_list_view.dart
+++ b/virotour/lib/src/tour/tour_list_view.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:virotour/src/settings/settings_view.dart';
 import 'package:virotour/src/tour/tour.dart';
 import 'package:virotour/src/tour/tour_details_view.dart';
+import 'package:virotour/src/tour/tour_edit_view.dart';
 
 class TourListView extends StatefulWidget {
   const TourListView({
@@ -57,14 +58,6 @@ class _TourListViewState extends State<TourListView> {
         title: const Text('Tours'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () {
-              setState(() {
-                _tourData = fetchData();
-              });
-            },
-          ),
-          IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
               Navigator.restorablePushNamed(context, SettingsView.routeName);
@@ -78,38 +71,69 @@ class _TourListViewState extends State<TourListView> {
             _tourData = fetchData();
           });
         },
-        child: FutureBuilder<List<Tour>>(
-          future: _tourData,
-          builder: (context, snapshot) {
-            if (snapshot.hasData) {
-              final items = snapshot.data!;
-              return ListView.builder(
-                restorationId: 'tourListView',
-                itemCount: items.length,
-                itemBuilder: (BuildContext context, int index) {
-                  final item = items[index];
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            const maxWidth = 800.0;
+            final isNarrow = constraints.maxWidth < maxWidth;
+            return Center(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: isNarrow ? constraints.maxWidth : maxWidth,
+                ),
+                child: FutureBuilder<List<Tour>>(
+                  future: _tourData,
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                      final items = snapshot.data!;
+                      return ListView.builder(
+                        restorationId: 'tourListView',
+                        itemCount: items.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          final item = items[index];
+                          String toTitleCase(String str) {
+                            if (str.isEmpty) return str;
+                            return str.substring(0, 1).toUpperCase() +
+                                str.substring(1);
+                          }
 
-                  return ListTile(
-                    title: Text(item.tourName),
-                    subtitle: Text(item.description),
-                    leading: const CircleAvatar(
-                      foregroundImage:
-                          AssetImage('assets/images/virotour_logo.png'),
-                    ),
-                    onTap: () {
-                      Navigator.restorablePushNamed(
-                        context,
-                        TourDetailsView.routeName,
+                          return ListTile(
+                            title: Text(toTitleCase(item.tourName)),
+                            subtitle: Text(toTitleCase(item.description)),
+                            leading: const CircleAvatar(
+                              foregroundImage:
+                                  AssetImage('assets/images/virotour_logo.png'),
+                            ),
+                            trailing: GestureDetector(
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => TourEditView(
+                                      tour: item,
+                                    ),
+                                  ),
+                                );
+                              },
+                              child: const Icon(Icons.edit),
+                            ),
+                            onTap: () {
+                              Navigator.restorablePushNamed(
+                                context,
+                                TourDetailsView.routeName,
+                              );
+                            },
+                          );
+                        },
                       );
-                    },
-                  );
-                },
-              );
-            } else if (snapshot.hasError) {
-              return Text('Error: ${snapshot.error}');
-            } else {
-              return const Center(child: CircularProgressIndicator());
-            }
+                    } else if (snapshot.hasError) {
+                      return Text('Error: ${snapshot.error}');
+                    } else {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+                  },
+                ),
+              ),
+            );
           },
         ),
       ),

--- a/virotour/pubspec.yaml
+++ b/virotour/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.3
   flutter:
     sdk: flutter
+  http: ^0.13.5
   webviewx: ^0.2.1
 
 dev_dependencies:


### PR DESCRIPTION
You should now see the tour name/description in the tour list.  
![image](https://user-images.githubusercontent.com/49327729/221071184-cf399ff7-1204-4553-8ce6-aaed07f36280.png)

Checkout this branch and merge Team B's API stable branch into it - `git merge add_flask_server_stable`.  You should now see a `flask` folder inside the `virotour` project.  Follow the instructions in the `flask/README.md` file to startup the server.

You are able to create/edit/delete tours through the API in browser and either click the refresh button or drag down to refresh (on mobile devices), which should update the list data with the new tour JSON.
I have tested on both Android and Browser, but am unable to test on iOS because I do not own a Mac.  